### PR TITLE
guard against filters failing to compile when properties are null

### DIFF
--- a/scene.yaml
+++ b/scene.yaml
@@ -61,7 +61,12 @@ layers:
         red:
             filter: |
                 function () {
-                    return feature[properties.key_text] && feature[properties.key_text].toLowerCase().indexOf(properties.value_text.toLowerCase()) > -1;
+                    return (
+                        properties.key_text &&
+                        properties.value_text &&
+                        feature[properties.key_text] &&
+                        feature[properties.key_text].toLowerCase().indexOf(properties.value_text.toLowerCase()) > -1
+                    );
                 }
             draw:
                 lines:
@@ -88,7 +93,12 @@ layers:
         red:
             filter: |
                 function () {
-                    return feature[properties.key_text] && feature[properties.key_text].toLowerCase().indexOf(properties.value_text.toLowerCase()) > -1;
+                    return (
+                        properties.key_text &&
+                        properties.value_text &&
+                        feature[properties.key_text] &&
+                        feature[properties.key_text].toLowerCase().indexOf(properties.value_text.toLowerCase()) > -1
+                    );
                 }
             draw:
                 lines:
@@ -123,7 +133,12 @@ layers:
         data: { source: mapillary }
         filter: |
             function() {
-                return feature.captured_at > properties.min && feature.captured_at < properties.max;
+                return (
+                    properties.min &&
+                    properties.max &&
+                    feature.captured_at > properties.min &&
+                    feature.captured_at < properties.max
+                );
             }
         properties: 
             key_text: ""
@@ -218,7 +233,12 @@ layers:
         red:
             filter: |
                 function () {
-                    return feature[properties.key_text] && feature[properties.key_text].toLowerCase().indexOf(properties.value_text.toLowerCase()) > -1;
+                    return (
+                        properties.key_text &&
+                        properties.value_text &&
+                        feature[properties.key_text] &&
+                        feature[properties.key_text].toLowerCase().indexOf(properties.value_text.toLowerCase()) > -1
+                    );
                 }
             draw:
                 lines:


### PR DESCRIPTION
when the filter is broken, all features apply the filtered style, which is usually not what was intended
